### PR TITLE
Reproduce Bottom Tab issue

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,6 +3,7 @@ import { enableScreens } from "react-native-screens";
 
 import { Tests, Test } from "./components";
 import BottomTabs from "./tests/BottomTabs";
+import BottomTabs2 from "./tests/BottomTabs2";
 import ListViewStack from "./tests/ListViewStack";
 import MaterialTopTabs from "./tests/MaterialTopTabs";
 import ModalIOS13PageSheet from "./tests/ModalIOS13PageSheet";
@@ -21,6 +22,7 @@ export default () => (
     <Test title="ModalStack" Component={ModalStack} />
     <Test title="ModalIOS13PageSheet" Component={ModalIOS13PageSheet} />
     <Test title="BottomTabs" Component={BottomTabs} />
+    <Test title="BottomTabs2" Component={BottomTabs2} />
     <Test title="MaterialTopTabs" Component={MaterialTopTabs} />
     <Test title="ListView" Component={ListViewStack} />
   </Tests>

--- a/example/src/tests/BottomTabs2.tsx
+++ b/example/src/tests/BottomTabs2.tsx
@@ -1,0 +1,59 @@
+import { createAppContainer } from "react-navigation";
+import { createSharedElementStackNavigator } from "react-navigation-shared-element";
+import { createBottomTabNavigator } from "react-navigation-tabs";
+
+import { createScreen, MasterScreen, DetailScreen } from "../screens";
+
+const StackNavigator1 = createSharedElementStackNavigator(
+  {
+    Master: createScreen(MasterScreen, "BottomStack1"),
+    Detail: DetailScreen
+  },
+  undefined,
+  {
+    name: "BottomStack1",
+    debug: true
+  }
+);
+
+StackNavigator1.navigationOptions = ({ navigation }) => {
+  let tabBarVisible = true;
+  if (navigation.state.index > 0) {
+    tabBarVisible = false;
+  }
+
+  return {
+    tabBarVisible
+  };
+};
+
+const StackNavigator2 = createSharedElementStackNavigator(
+  {
+    Master: createScreen(MasterScreen, "BottomStack2"),
+    Detail: DetailScreen
+  },
+  undefined,
+  {
+    name: "BottomStack2",
+    debug: true
+  }
+);
+
+const TabNavigator = createBottomTabNavigator({
+  Tab1: {
+    // @ts-ignore
+    screen: StackNavigator1,
+    navigationOptions: {
+      title: "Stack 1"
+    }
+  },
+  Tab2: {
+    // @ts-ignore
+    screen: StackNavigator2,
+    navigationOptions: {
+      title: "Stack 2"
+    }
+  }
+});
+
+export default createAppContainer(TabNavigator);


### PR DESCRIPTION
# Summary
Reproduce Bottom Tab issue #42. In the images below, we can see that there's a glitch when we navigate from the Master screen to the Detail screen and when we go back because of the bottom tab.
# Changes proposed in this pull request
Add a new `BottomTabs2` test.
# Screenshots

![bottom_tab_ios](https://user-images.githubusercontent.com/4929170/79193325-9b88ae00-7e54-11ea-909e-3b74d449bf84.gif)|![bottom_tab_android](https://user-images.githubusercontent.com/4929170/79193351-a6434300-7e54-11ea-93dd-5c98c5f2eb37.gif)
:-:|:-:
iOS|Android
