### PR TITLE
Hide bottom tab the correct way

### DIFF
--- a/example/src/tests/BottomTabs2.tsx
+++ b/example/src/tests/BottomTabs2.tsx
@@ -2,58 +2,35 @@ import { createAppContainer } from "react-navigation";
 import { createSharedElementStackNavigator } from "react-navigation-shared-element";
 import { createBottomTabNavigator } from "react-navigation-tabs";
 
-import { createScreen, MasterScreen, DetailScreen } from "../screens";
-
-const StackNavigator1 = createSharedElementStackNavigator(
-  {
-    Master: createScreen(MasterScreen, "BottomStack1"),
-    Detail: DetailScreen
-  },
-  undefined,
-  {
-    name: "BottomStack1",
-    debug: true
-  }
-);
-
-StackNavigator1.navigationOptions = ({ navigation }) => {
-  let tabBarVisible = true;
-  if (navigation.state.index > 0) {
-    tabBarVisible = false;
-  }
-
-  return {
-    tabBarVisible
-  };
-};
-
-const StackNavigator2 = createSharedElementStackNavigator(
-  {
-    Master: createScreen(MasterScreen, "BottomStack2"),
-    Detail: DetailScreen
-  },
-  undefined,
-  {
-    name: "BottomStack2",
-    debug: true
-  }
-);
+import { MasterScreen, DetailScreen } from "../screens";
 
 const TabNavigator = createBottomTabNavigator({
   Tab1: {
     // @ts-ignore
-    screen: StackNavigator1,
+    screen: MasterScreen,
     navigationOptions: {
       title: "Stack 1"
     }
   },
   Tab2: {
     // @ts-ignore
-    screen: StackNavigator2,
+    screen: MasterScreen,
     navigationOptions: {
       title: "Stack 2"
     }
   }
 });
 
-export default createAppContainer(TabNavigator);
+const MainStack = createSharedElementStackNavigator(
+  {
+    Master: TabNavigator,
+    Detail: DetailScreen
+  },
+  undefined,
+  {
+    name: "MainStack",
+    debug: true
+  }
+);
+
+export default createAppContainer(MainStack);


### PR DESCRIPTION
# Summary
According to this document https://reactnavigation.org/docs/hiding-tabbar-in-screens/. Issue #42 is because we was hiding the bottom tab the wrong way. This PR restructures the navigation following this guide.

But after restructuring, the animation does not work at all.

# Changes proposed in this pull request
Restructures the navigation following  the recommended document by react-navigation team.
# Screenshots

![bottom_tab_android_2](https://user-images.githubusercontent.com/4929170/79216809-00a1cb00-7e78-11ea-948b-8f07b963801c.gif)|![bottom_tab_ios_2](https://user-images.githubusercontent.com/4929170/79216825-07c8d900-7e78-11ea-8104-6ac28a314be2.gif)
:-:|:-:
Android|iOS