### PR TITLE
Reproduce bug when animating TextInput

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -11,6 +11,7 @@ import ModalStack from "./tests/ModalStack";
 import NestedStack from "./tests/NestedStack";
 import NestedStack2 from "./tests/NestedStack2";
 import SimpleStack from "./tests/SimpleStack";
+import TextInputStack from "./tests/TextInputStack";
 
 enableScreens();
 
@@ -25,5 +26,6 @@ export default () => (
     <Test title="BottomTabs2" Component={BottomTabs2} />
     <Test title="MaterialTopTabs" Component={MaterialTopTabs} />
     <Test title="ListView" Component={ListViewStack} />
+    <Test title="TextInput" Component={TextInputStack} />
   </Tests>
 );

--- a/example/src/tests/TextInputStack.tsx
+++ b/example/src/tests/TextInputStack.tsx
@@ -1,0 +1,72 @@
+import { View, TextInput, Keyboard } from "react-native";
+import React from "react";
+import { createAppContainer } from "react-navigation";
+import { HeaderBackButton } from "react-navigation-stack";
+import {
+  SharedElement,
+  createSharedElementStackNavigator
+} from "react-navigation-shared-element";
+import { useSafeArea } from "react-native-safe-area-context";
+
+const SearchInput = props => (
+  <TextInput
+    {...props}
+    placeholder="Search"
+    style={{
+      width: "80%",
+      height: 40,
+      padding: 3,
+      borderWidth: 1,
+      borderColor: "red"
+    }}
+  />
+);
+
+const HomeScreen = ({ navigation }) => {
+  return (
+    <View style={{ flex: 1 }}>
+      <SharedElement id="searchBar" style={{ padding: 15 }}>
+        <SearchInput onFocus={() => navigation.navigate("Search")} />
+      </SharedElement>
+    </View>
+  );
+};
+
+const SearchScreen = ({ navigation }) => {
+  const { top: topInsect } = useSafeArea();
+  return (
+    <View style={{ flexDirection: "row", marginTop: topInsect + 5 }}>
+      <HeaderBackButton
+        onPress={() => {
+          // buggy if we just goBack
+          navigation.goBack();
+
+          // Hide keyboard and setTimeout to
+          // wait for the keyboard to close
+          // Keyboard.dismiss();
+          // setTimeout(() => navigation.goBack(), 500);
+        }}
+      />
+      <SharedElement id="searchBar" style={{ flex: 1 }}>
+        <SearchInput autoFocus />
+      </SharedElement>
+    </View>
+  );
+};
+
+SearchScreen.navigationOptions = { headerShown: false };
+SearchScreen.sharedElements = () => [{ id: "searchBar" }];
+
+const TextInputStackNavigator = createSharedElementStackNavigator(
+  {
+    Home: HomeScreen,
+    Search: SearchScreen
+  },
+  undefined,
+  {
+    name: "TextInputStack",
+    debug: true
+  }
+);
+
+export default createAppContainer(TextInputStackNavigator);


### PR DESCRIPTION
# Summary
Reproduce TextInput issue. In the images below, we can see that there's a glitch when we navigate back from the Search screen to the Home screen because the keyboard is open.
# Changes proposed in this pull request
Add a new `TextInput` test.
# Screenshots

![android_text_input_issue](https://user-images.githubusercontent.com/4929170/79300168-24b0eb00-7f10-11ea-9756-1f7ce4e0eb76.gif)|
:-:|
