### PR TITLE
Extract stack view and navigator factory

### DIFF
--- a/src/SharedElementStackView.tsx
+++ b/src/SharedElementStackView.tsx
@@ -1,0 +1,79 @@
+import { StackNavigationState } from "@react-navigation/native";
+import { StackView } from "@react-navigation/stack";
+import {
+  StackDescriptorMap,
+  StackNavigationConfig,
+  StackNavigationHelpers,
+} from "@react-navigation/stack/lib/typescript/src/types";
+import * as React from "react";
+
+import { useSharedElementFocusEvents } from "./SharedElementFocusEvents";
+import SharedElementRendererContext from "./SharedElementRendererContext";
+import SharedElementRendererData from "./SharedElementRendererData";
+import { SharedElementRendererProxy } from "./SharedElementRendererProxy";
+import SharedElementRendererView from "./SharedElementRendererView";
+import { EventEmitter } from "./utils/EventEmitter";
+
+type SharedElementViewProps = StackNavigationConfig & {
+  state: StackNavigationState;
+  navigation: StackNavigationHelpers;
+  descriptors: StackDescriptorMap;
+} & {
+  debug?: boolean;
+  rendererDataProxy: SharedElementRendererProxy;
+  emitter: EventEmitter;
+};
+
+export function SharedElementStackView({
+  state,
+  descriptors,
+  navigation,
+  debug,
+  rendererDataProxy,
+  emitter,
+  ...rest
+}: SharedElementViewProps) {
+  const rendererDataRef = React.useRef<SharedElementRendererData | null>(null);
+
+  if (debug) {
+    React.useLayoutEffect(() => {
+      rendererDataProxy.addDebugRef();
+      return function cleanup() {
+        rendererDataProxy.releaseDebugRef();
+      };
+    }, []);
+  }
+
+  useSharedElementFocusEvents({ state, emitter });
+
+  return (
+    <SharedElementRendererContext.Consumer>
+      {(rendererData) => {
+        // In case a renderer is already present higher up in the chain
+        // then don't bother creating a renderer here, but use that one instead
+        if (!rendererData) {
+          rendererDataRef.current =
+            rendererDataRef.current || new SharedElementRendererData();
+          rendererDataProxy.source = rendererDataRef.current;
+        } else {
+          rendererDataProxy.source = rendererData;
+        }
+        return (
+          <SharedElementRendererContext.Provider value={rendererDataProxy}>
+            <StackView
+              {...rest}
+              state={state}
+              descriptors={descriptors}
+              navigation={navigation}
+            />
+            {rendererDataRef.current ? (
+              <SharedElementRendererView
+                rendererData={rendererDataRef.current}
+              />
+            ) : undefined}
+          </SharedElementRendererContext.Provider>
+        );
+      }}
+    </SharedElementRendererContext.Consumer>
+  );
+}

--- a/src/createSharedElementNavigatorFactory.tsx
+++ b/src/createSharedElementNavigatorFactory.tsx
@@ -1,0 +1,143 @@
+import {
+  createNavigatorFactory,
+  RouteConfig,
+  StackNavigationState,
+} from "@react-navigation/native";
+import {
+  CardAnimationContext,
+  StackNavigationOptions,
+} from "@react-navigation/stack";
+import { StackNavigationEventMap } from "@react-navigation/stack/lib/typescript/src/types";
+import * as React from "react";
+
+import createSharedElementScene from "./createSharedElementScene";
+import {
+  SharedElementSceneComponent,
+  SharedElementsComponentConfig,
+} from "./types";
+
+export function createSharedElementNavigatorFactory<
+  ParamList extends Record<string, object | undefined>
+>(rendererDataProxy, emitter, navigatorId, debug) {
+  return function (sharedElementNavigatorComponent) {
+    const navigatorFactory = createNavigatorFactory<
+      StackNavigationState,
+      StackNavigationOptions,
+      StackNavigationEventMap,
+      typeof sharedElementNavigatorComponent
+    >(sharedElementNavigatorComponent);
+
+    const { Navigator, Screen } = navigatorFactory<ParamList>();
+
+    type ScreenProps<RouteName extends keyof ParamList> = Omit<
+      RouteConfig<
+        ParamList,
+        RouteName,
+        StackNavigationState,
+        StackNavigationOptions,
+        StackNavigationEventMap
+      >,
+      "component" | "children"
+    > & {
+      component: SharedElementSceneComponent;
+      sharedElements?: SharedElementsComponentConfig;
+
+      /**
+       * @deprecated
+       * The `sharedElementsConfig` prop has been renamed, use `sharedElements` instead.
+       */
+      sharedElementsConfig?: SharedElementsComponentConfig;
+    };
+
+    // Wrapping Screen to explicitly statically type a "Shared Element" Screen.
+    function wrapScreen<RouteName extends keyof ParamList>(
+      _: ScreenProps<RouteName>
+    ) {
+      return null;
+    }
+
+    type NavigatorProps = React.ComponentProps<typeof Navigator>;
+
+    function getSharedElementsChildrenProps(children: React.ReactNode) {
+      return React.Children.toArray(children).reduce<any[]>((acc, child) => {
+        if (React.isValidElement(child)) {
+          if (child.type === wrapScreen) {
+            acc.push(child.props);
+          }
+
+          if (child.type === React.Fragment) {
+            acc.push(...getSharedElementsChildrenProps(child.props.children));
+          }
+        }
+        return acc;
+      }, []);
+    }
+
+    // react-navigation only allows the Screen component as direct children
+    // of Navigator, this is why we need to wrap the Navigator
+    function WrapNavigator(props: NavigatorProps) {
+      const { children, ...restProps } = props;
+      const wrappedComponentsCache = React.useRef<Map<string, any>>(new Map());
+      const screenChildrenProps = getSharedElementsChildrenProps(children);
+
+      return (
+        <Navigator {...restProps}>
+          {screenChildrenProps.map(
+            ({
+              component,
+              name,
+              sharedElements,
+              sharedElementsConfig,
+              ...restChildrenProps
+            }) => {
+              sharedElements = sharedElements || sharedElementsConfig;
+
+              // Show warning when deprecated `sharedElementsConfig` prop was used
+              if (sharedElementsConfig) {
+                console.warn(
+                  "The `sharedElementsConfig` prop has been renamed, use `sharedElements` instead."
+                );
+              }
+
+              // Check whether this component was previously already wrapped
+              let wrappedComponent = wrappedComponentsCache.current.get(name);
+              if (
+                !wrappedComponent ||
+                wrappedComponent.config.Component !== component
+              ) {
+                // Wrap the component
+                wrappedComponent = createSharedElementScene(
+                  component,
+                  sharedElements,
+                  rendererDataProxy,
+                  emitter,
+                  CardAnimationContext,
+                  navigatorId,
+                  debug
+                );
+                wrappedComponentsCache.current.set(name, wrappedComponent);
+              } else {
+                // Shared elements function might have been changed, so update it
+                wrappedComponent.config.sharedElements = sharedElements;
+              }
+
+              return (
+                <Screen
+                  key={name}
+                  name={name}
+                  component={wrappedComponent}
+                  {...restChildrenProps}
+                />
+              );
+            }
+          )}
+        </Navigator>
+      );
+    }
+
+    return {
+      Navigator: WrapNavigator,
+      Screen: wrapScreen,
+    };
+  };
+}

--- a/src/createSharedElementScene.tsx
+++ b/src/createSharedElementScene.tsx
@@ -1,4 +1,5 @@
 import { Route, NavigationState } from "@react-navigation/native";
+import { PartialState } from "@react-navigation/routers"
 import {
   StackNavigationProp,
   StackCardInterpolationProps,
@@ -31,7 +32,7 @@ type PropsType = {
 };
 
 function isValidNavigationState(
-  state: Partial<NavigationState>
+  state: NavigationState | PartialState<NavigationState>
 ): state is NavigationState {
   return "index" in state && "routes" in state;
 }

--- a/src/createSharedElementStackNavigator.tsx
+++ b/src/createSharedElementStackNavigator.tsx
@@ -1,15 +1,11 @@
 import {
   useNavigationBuilder,
-  createNavigatorFactory,
   DefaultNavigatorOptions,
-  RouteConfig,
   StackRouter,
   StackRouterOptions,
   StackNavigationState,
 } from "@react-navigation/native";
 import {
-  CardAnimationContext,
-  StackView,
   StackNavigationOptions,
 } from "@react-navigation/stack";
 import {
@@ -20,15 +16,9 @@ import * as React from "react";
 import { Platform } from "react-native";
 
 import { useSharedElementFocusEvents } from "./SharedElementFocusEvents";
-import SharedElementRendererContext from "./SharedElementRendererContext";
-import SharedElementRendererData from "./SharedElementRendererData";
 import { SharedElementRendererProxy } from "./SharedElementRendererProxy";
-import SharedElementRendererView from "./SharedElementRendererView";
-import createSharedElementScene from "./createSharedElementScene";
-import {
-  SharedElementSceneComponent,
-  SharedElementsComponentConfig,
-} from "./types";
+import { SharedElementStackView } from "./SharedElementStackView";
+import { createSharedElementNavigatorFactory } from "./createSharedElementNavigatorFactory";
 import { EventEmitter } from "./utils/EventEmitter";
 
 let _navigatorId = 1;
@@ -92,10 +82,6 @@ export default function createSharedElementStackNavigator<
             },
     });
 
-    const rendererDataRef = React.useRef<SharedElementRendererData | null>(
-      null
-    );
-
     if (debug) {
       React.useLayoutEffect(() => {
         rendererDataProxy.addDebugRef();
@@ -108,154 +94,21 @@ export default function createSharedElementStackNavigator<
     useSharedElementFocusEvents({ state, emitter });
 
     return (
-      <SharedElementRendererContext.Consumer>
-        {(rendererData) => {
-          // In case a renderer is already present higher up in the chain
-          // then don't bother creating a renderer here, but use that one instead
-          if (!rendererData) {
-            rendererDataRef.current =
-              rendererDataRef.current || new SharedElementRendererData();
-            rendererDataProxy.source = rendererDataRef.current;
-          } else {
-            rendererDataProxy.source = rendererData;
-          }
-          return (
-            <SharedElementRendererContext.Provider value={rendererDataProxy}>
-              <StackView
-                {...rest}
-                state={state}
-                descriptors={descriptors}
-                navigation={navigation}
-              />
-              {rendererDataRef.current ? (
-                <SharedElementRendererView
-                  rendererData={rendererDataRef.current}
-                />
-              ) : undefined}
-            </SharedElementRendererContext.Provider>
-          );
-        }}
-      </SharedElementRendererContext.Consumer>
+      <SharedElementStackView
+        state={state}
+        navigation={navigation}
+        descriptors={descriptors}
+        rendererDataProxy={rendererDataProxy}
+        emitter={emitter}
+        {...rest}
+      />
     );
   }
 
-  const navigatorFactory = createNavigatorFactory<
-    StackNavigationState,
-    StackNavigationOptions,
-    StackNavigationEventMap,
-    typeof SharedElementStackNavigator
-  >(SharedElementStackNavigator);
-
-  const { Navigator, Screen } = navigatorFactory<ParamList>();
-
-  type ScreenProps<RouteName extends keyof ParamList> = Omit<
-    RouteConfig<
-      ParamList,
-      RouteName,
-      StackNavigationState,
-      StackNavigationOptions,
-      StackNavigationEventMap
-    >,
-    "component" | "children"
-  > & {
-    component: SharedElementSceneComponent;
-    sharedElements?: SharedElementsComponentConfig;
-
-    /**
-     * @deprecated
-     * The `sharedElementsConfig` prop has been renamed, use `sharedElements` instead.
-     */
-    sharedElementsConfig?: SharedElementsComponentConfig;
-  };
-
-  // Wrapping Screen to explicitly statically type a "Shared Element" Screen.
-  function wrapScreen<RouteName extends keyof ParamList>(
-    _: ScreenProps<RouteName>
-  ) {
-    return null;
-  }
-
-  type NavigatorProps = React.ComponentProps<typeof Navigator>;
-
-  function getSharedElementsChildrenProps(children: React.ReactNode) {
-    return React.Children.toArray(children).reduce<any[]>((acc, child) => {
-      if (React.isValidElement(child)) {
-        if (child.type === wrapScreen) {
-          acc.push(child.props);
-        }
-
-        if (child.type === React.Fragment) {
-          acc.push(...getSharedElementsChildrenProps(child.props.children));
-        }
-      }
-      return acc;
-    }, []);
-  }
-
-  // react-navigation only allows the Screen component as direct children
-  // of Navigator, this is why we need to wrap the Navigator
-  function WrapNavigator(props: NavigatorProps) {
-    const { children, ...restProps } = props;
-    const wrappedComponentsCache = React.useRef<Map<string, any>>(new Map());
-    const screenChildrenProps = getSharedElementsChildrenProps(children);
-
-    return (
-      <Navigator {...restProps}>
-        {screenChildrenProps.map(
-          ({
-            component,
-            name,
-            sharedElements,
-            sharedElementsConfig,
-            ...restChildrenProps
-          }) => {
-            sharedElements = sharedElements || sharedElementsConfig;
-
-            // Show warning when deprecated `sharedElementsConfig` prop was used
-            if (sharedElementsConfig) {
-              console.warn(
-                "The `sharedElementsConfig` prop has been renamed, use `sharedElements` instead."
-              );
-            }
-
-            // Check whether this component was previously already wrapped
-            let wrappedComponent = wrappedComponentsCache.current.get(name);
-            if (
-              !wrappedComponent ||
-              wrappedComponent.config.Component !== component
-            ) {
-              // Wrap the component
-              wrappedComponent = createSharedElementScene(
-                component,
-                sharedElements,
-                rendererDataProxy,
-                emitter,
-                CardAnimationContext,
-                navigatorId,
-                debug
-              );
-              wrappedComponentsCache.current.set(name, wrappedComponent);
-            } else {
-              // Shared elements function might have been changed, so update it
-              wrappedComponent.config.sharedElements = sharedElements;
-            }
-
-            return (
-              <Screen
-                key={name}
-                name={name}
-                component={wrappedComponent}
-                {...restChildrenProps}
-              />
-            );
-          }
-        )}
-      </Navigator>
-    );
-  }
-
-  return {
-    Navigator: WrapNavigator,
-    Screen: wrapScreen,
-  };
+  return createSharedElementNavigatorFactory<ParamList>(
+    rendererDataProxy,
+    emitter,
+    navigatorId,
+    debug
+  )(SharedElementStackNavigator);
 }


### PR DESCRIPTION
File createSharedElementStackNavigator.tsx has a lot of stuff in it and that makes it hard or close to impossible (without copying the entire thing) to make a custom Navigator that uses a custom Router. It would be nice to extract and export the View used within the Navigator and a factory creation function that wraps both Navigator and Screen components. That would make it possible to create a custom createSharedElementStackNavigator function that uses a custom Router inside without copying a lot of the shared-element-related code.