### PR TITLE
Add prop types to SharedElementSceneComponent

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,6 @@ export type SharedElementsComponentConfig = (
   showing: boolean
 ) => SharedElementsConfig | undefined;
 
-export type SharedElementSceneComponent = React.ComponentType<any> & {
+export type SharedElementSceneComponent<P = {}> = React.ComponentType<P> & {
   sharedElements?: SharedElementsComponentConfig;
 };


### PR DESCRIPTION
Using `any` remove the type checking, so now it is possible to specify a *generic type* to have props type checking in the same way [`React.ComponentType`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L82) does, while it still accepts an `any` type as generic.

## Old behavior

![old-behavior](https://user-images.githubusercontent.com/26308880/97052129-d469b400-1556-11eb-898a-e91bbed5506c.png)

## Current behavior

### Default behavior
![current-default-behavior](https://user-images.githubusercontent.com/26308880/97052126-d3d11d80-1556-11eb-964e-c3012a689353.png)

### Using `any` as before
![current-any-behavior](https://user-images.githubusercontent.com/26308880/97052124-d29ff080-1556-11eb-8374-2fc6cc830b8f.png)

### Setting prop types
![current-prop-types](https://user-images.githubusercontent.com/26308880/97052127-d3d11d80-1556-11eb-9f67-8a0cc4d3f454.png)