### PR TITLE
Add prop types to SharedElementSceneComponent

### DIFF
--- a/src/createSharedElementStackNavigator.tsx
+++ b/src/createSharedElementStackNavigator.tsx
@@ -158,7 +158,7 @@ export default function createSharedElementStackNavigator<
     >,
     "component" | "children"
   > & {
-    component: SharedElementSceneComponent;
+    component: SharedElementSceneComponent<any>;
     sharedElements?: SharedElementsComponentConfig;
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,6 @@ export type SharedElementsComponentConfig = (
   showing: boolean
 ) => SharedElementsConfig | undefined;
 
-export type SharedElementSceneComponent = React.ComponentType<any> & {
+export type SharedElementSceneComponent<P = {}> = React.ComponentType<P> & {
   sharedElements?: SharedElementsComponentConfig;
 };


### PR DESCRIPTION
Using `any` remove the Screen component props type checking, so now it is possible to specify a *generic type* to have props type checking in the same way [`React.ComponentType`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L82) does, while it still accepts an `any` type as generic as I did in `ScreenProps.component` in `createSharedEelementStackNavigator` (same way as [`RouteConfig.component` in `RouteConfig`](https://github.com/react-navigation/react-navigation/blob/7dc2f5832e371473f3263c01ab39824eb9e2057d/packages/core/src/types.tsx#L399) from `@react-navigation/core`).

## Old behavior

![old-behavior](https://user-images.githubusercontent.com/26308880/97052129-d469b400-1556-11eb-898a-e91bbed5506c.png)

## Current behavior

### Default behavior
![current-default-behavior](https://user-images.githubusercontent.com/26308880/97052126-d3d11d80-1556-11eb-964e-c3012a689353.png)

### Using `any` as before
![current-any-behavior](https://user-images.githubusercontent.com/26308880/97052124-d29ff080-1556-11eb-8374-2fc6cc830b8f.png)

### Setting prop types
![current-prop-types](https://user-images.githubusercontent.com/26308880/97052127-d3d11d80-1556-11eb-9f67-8a0cc4d3f454.png)